### PR TITLE
package.json updates - release version and adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/callstack-internal/react-native-windows-hello.git",
-    "baseUrl": "https://github.com/callstack-internal/react-native-windows-hello"
+    "url": "git+https://github.com/callstack/react-native-windows-hello.git",
+    "baseUrl": "https://github.com/callstack/react-native-windows-hello"
   },
   "keywords": [
     "react-native-windows",


### PR DESCRIPTION
This pull request adjusts the *package.json* file to the release version.
It:
* Bumps the version to 0.8.0 just like it's mentioned in #9
* Updates the files included in the released package (added README and LICENSE)
* Uses the [Callstack](https://github.com/callstack) organization page of GitHub
This is to make sure that once the package is published, the URL is correct.

