### PR TITLE
Make both JS methods of `SignInModule` static

### DIFF
--- a/source/SignInModule.js
+++ b/source/SignInModule.js
@@ -6,7 +6,7 @@ import {
 } from "./Statuses";
 
 export class SignInModule {
-  requestConsentVerification(promptMessage = "") {
+  static requestConsentVerification(promptMessage = "") {
     return new Promise((resolve, reject) => {
       if (typeof promptMessage === "string") {
         NativeModules.SignIn.requestScanPromise(promptMessage)
@@ -27,7 +27,7 @@ export class SignInModule {
     });
   }
 
-  getDeviceStatus() {
+  static getDeviceStatus() {
     return new Promise((resolve, reject) => {
       NativeModules.SignIn.checkAvailabilityPromise()
         .then((result) => {


### PR DESCRIPTION
This pull request makes both `requestConsentVerification` and `getDeviceStatus` methods static.
This is to avoid the requirement of creating the `SignIn` object each time these methods are to be used.
There's also no need to keep those values non-static, as this class doesn't contain any fields or properties that should be bound to specific instance of this class.
